### PR TITLE
Use http for internal keycloak urls

### DIFF
--- a/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
+++ b/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
@@ -50,7 +50,7 @@ LogLevel info
     LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\"" logformat
     CustomLog "{{ keystone_log_dir }}/keystone-apache-public-access.log" logformat
 
-    OIDCProviderMetadataURL https://testbed-gx-iam.osism.test:8170/auth/realms/keystone/.well-known/openid-configuration
+    OIDCProviderMetadataURL http://testbed-gx-iam.osism.test:8170/auth/realms/keystone/.well-known/openid-configuration
     OIDCRedirectURI https://testbed-gx-iam.osism.test:5000/v3/OS-FEDERATION/identity_providers/keycloak/protocols/mapped/auth
 
     OIDCClientID keystone
@@ -96,7 +96,7 @@ LogLevel info
     LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\"" logformat
     CustomLog "{{ keystone_log_dir }}/keystone-apache-admin-access.log" logformat
 
-    OIDCProviderMetadataURL https://testbed-gx-iam.osism.test:8170/auth/realms/keystone/.well-known/openid-configuration
+    OIDCProviderMetadataURL http://testbed-gx-iam.osism.test:8170/auth/realms/keystone/.well-known/openid-configuration
     OIDCRedirectURI https://testebd-iam.osism.test:5000/v3/OS-FEDERATION/identity_providers/keycloak/protocols/mapped/auth
 
     OIDCClientID keystone


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>